### PR TITLE
Enable thumbnails to load via HTTPS.

### DIFF
--- a/www/app/coverart/mopidy.js
+++ b/www/app/coverart/mopidy.js
@@ -22,8 +22,9 @@
       var settings = connection.settings();
       var resolve = settings.webSocketUrl ? function(image) {
         if (image.uri.charAt(0) == '/') {
-          var match = /^wss?:\/\/([^\/]+)/.exec(settings.webSocketUrl);
-          return angular.extend({uri: 'http://' + match[1] + image.uri});
+          var match = /^ws(s?):\/\/([^\/]+)/.exec(settings.webSocketUrl);
+          var protocol = 'http' + match[1];
+          return angular.extend({uri: protocol + '://' + match[2] + image.uri});
         } else {
           return image;
         }


### PR DESCRIPTION
When using a secure WebSocket, thumbnails were still loaded via HTTP instead of HTTPS. This PR switches to HTTPS in case WSS is used.