### PR TITLE
CovertArt, allow HTTPS and remove credentials

### DIFF
--- a/www/app/coverart/mopidy.js
+++ b/www/app/coverart/mopidy.js
@@ -22,8 +22,10 @@
       var settings = connection.settings();
       var resolve = settings.webSocketUrl ? function(image) {
         if (image.uri.charAt(0) == '/') {
-          var match = /^wss?:\/\/([^\/]+)/.exec(settings.webSocketUrl);
-          return angular.extend({uri: 'http://' + match[1] + image.uri});
+          var url = new URL(settings.webSocketUrl);
+          var protocol = url.protocol === 'ws' ? 'http' : 'https';
+          var uri = protocol + '://' + url.hostname + ":" + url.port + image.uri;
+          return angular.extend({ uri });
         } else {
           return image;
         }


### PR DESCRIPTION
This PR fixes two things:
1. it allows coverart to be loaded via HTTPS
2. If you're using basic authentication (https://username:password@hostname) to access mopidy, coverart will now load on Android. Previously, supplying credentials in the img src uri caused CSP errors for me.