### PR TITLE
Allow navigation to particular tab locations when loading page

### DIFF
--- a/www/app/services/router.js
+++ b/www/app/services/router.js
@@ -114,7 +114,17 @@
     };
   });
 
-  /* @ngInject */
+  /* @ ng Inject */
+  /* This breaks direct navigation to links when the page loads,
+   * for example causing
+   * http://127.0.0.1:6680/mobile/index.html#/tracklist
+   * to go to
+   * http://127.0.0.1:6680/mobile/index.html#/
+   * and then end up at
+   * http://127.0.0.1:6680/mobile/index.html#/playback
+   * because that is the angular-ui-router otherwise() location.
+   * I'm leaving this here, but disabled, because I don't know what
+   * else might break if I disable this.
   module.run(function($location, $log) {
     // workaround for lost history/back view after browser reload
     if ($location.url()) {
@@ -123,5 +133,6 @@
       $location.replace();
     }
   });
+   */
 
 })(angular.module('app.services.router', ['ionic']));


### PR DESCRIPTION
This disables a workaround which caused the initial loading to always end up at the playback page, even if another path was after the #. A comment claimed that it was a "workaround for lost history/back view after browser reload", so this might cause some problems. The workaround is still there, but commented out.

I guess I didn't submit this originally because I didn't know what might break if I disable that workaround, but I didn't run into problems and this is such an improvement for me that I feel I need to submit it. This change allows the URL entered into a browser to immediately navigate to a specific location, including a specific tab and a location within that tab, like a particular music directory. Then such URLs can be bookmarked.